### PR TITLE
Include cookie in login request

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ## Login Method
 
-This repository includes a method to log in to ParentSquare using an authenticity token, username, and password.
+This repository includes a method to log in to ParentSquare using an authenticity token, username, password, and cookie.
 
 ### Usage
 
 1. Retrieve the authenticity token and cookie from the sessions page.
-2. Call the `login` method with the authenticity token, username, and password.
+2. Call the `login` method with the authenticity token, username, password, and cookie.
 3. Parse the username and password from a JSON file specified by a command line argument.
 
 ### Example JSON File

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func getSessionData() (string, string, error) {
 	return authenticityToken, cookie, nil
 }
 
-func login(authenticityToken, username, password string) error {
+func login(authenticityToken, username, password, cookie string) error {
 	data := url.Values{}
 	data.Set("utf8", "✓")
 	data.Set("authenticity_token", authenticityToken)
@@ -91,6 +91,7 @@ func login(authenticityToken, username, password string) error {
 	req.Header.Set("Sec-Fetch-User", "?1")
 	req.Header.Set("Upgrade-Insecure-Requests", "1")
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
+	req.Header.Set("Cookie", cookie)
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -136,7 +137,7 @@ func main() {
 	fmt.Println("Authenticity Token:", authenticityToken)
 	fmt.Println("Cookie:", cookie)
 
-	err = login(authenticityToken, username, password)
+	err = login(authenticityToken, username, password, cookie)
 	if err != nil {
 		fmt.Println("Login Error:", err)
 		return


### PR DESCRIPTION
Related to #11

Include cookie in login request.

* Modify the `login` function in `main.go` to accept an additional `cookie` parameter.
* Add `req.Header.Set("Cookie", cookie)` in the `login` function to set the cookie in the request headers.
* Update the `main` function in `main.go` to pass the `cookie` to the `login` function.
* Update the "Login Method" section in `README.md` to mention the inclusion of the cookie in the login request.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/parentsquare-namehelp/pull/12?shareId=4231de43-43e8-4276-9a08-cba78dfdb074).