### PR TITLE
Log out the 'curl' CLI equivalent of the request made in the login method

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Login Method
 
-This repository includes a method to log in to ParentSquare using an authenticity token, username, password, and cookie.
+This repository includes a method to log in to ParentSquare using an authenticity token, username, password, and cookie. The `login` method also logs out the 'curl' CLI equivalent of the request made, including URL, headers, and form data.
 
 ### Usage
 

--- a/main.go
+++ b/main.go
@@ -62,6 +62,17 @@ func getSessionData() (string, string, error) {
 	return authenticityToken, cookie, nil
 }
 
+func logCurlEquivalent(url, method string, headers map[string]string, data url.Values) {
+	curlCommand := fmt.Sprintf("curl -X %s '%s'", method, url)
+	for key, value in headers {
+		curlCommand += fmt.Sprintf(" -H '%s: %s'", key, value)
+	}
+	if data != nil {
+		curlCommand += fmt.Sprintf(" -d '%s'", data.Encode())
+	}
+	fmt.Println("Curl Equivalent:", curlCommand)
+}
+
 func login(authenticityToken, username, password, cookie string) error {
 	data := url.Values{}
 	data.Set("utf8", "✓")
@@ -69,6 +80,13 @@ func login(authenticityToken, username, password, cookie string) error {
 	data.Set("session[email]", username)
 	data.Set("session[password]", password)
 	data.Set("commit", "Sign In")
+
+	headers := map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+		"Cookie": cookie,
+	}
+
+	logCurlEquivalent("https://www.parentsquare.com/sessions", "POST", headers, data)
 
 	req, err := http.NewRequest("POST", "https://www.parentsquare.com/sessions", strings.NewReader(data.Encode()))
 	if err != nil {


### PR DESCRIPTION
Related to #15

Add logging of 'curl' CLI equivalent in the `login` method.

* Add a new function `logCurlEquivalent` in `main.go` to generate and log the 'curl' CLI equivalent of the request.
* Call `logCurlEquivalent` in the `login` function before sending the request.
* Update `README.md` to mention that the `login` method logs out the 'curl' CLI equivalent of the request made.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/parentsquare-namehelp/issues/15?shareId=XXXX-XXXX-XXXX-XXXX).