### PR TITLE
Implement a method to query the autocomplete service

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,25 @@ This repository includes a method to log in to ParentSquare using an authenticit
   }
 }
 ```
+
+## Autocomplete Query Method
+
+This repository now includes a method to query the autocomplete service using the provided cURL command as a model.
+
+### Usage
+
+1. Call the `queryAutocomplete` method with the cookie, CSRF token, and query string.
+2. The method constructs the request using the provided cURL command as a model.
+3. The method sends the request and returns the response.
+
+### Example Query
+
+```go
+query := "cha" // Example query
+response, err := queryAutocomplete(cookie, csrfToken, query)
+if err != nil {
+    fmt.Println("Autocomplete Query Error:", err)
+    return
+}
+fmt.Println("Autocomplete Response:", response)
+```

--- a/main.go
+++ b/main.go
@@ -103,6 +103,46 @@ func login(authenticityToken, username, password, cookie string) error {
 	return nil
 }
 
+func queryAutocomplete(cookie, csrfToken, query string) (string, error) {
+	url := fmt.Sprintf("https://www.parentsquare.com/schools/732/users/autocomplete?limit=25&chat=1&query=%s", url.QueryEscape(query))
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("accept", "application/json, text/javascript, */*; q=0.01")
+	req.Header.Set("accept-language", "en")
+	req.Header.Set("cache-control", "no-cache")
+	req.Header.Set("pragma", "no-cache")
+	req.Header.Set("priority", "u=1, i")
+	req.Header.Set("referer", "https://www.parentsquare.com/schools/732/users/24399867/chats/new?private=true")
+	req.Header.Set("sec-ch-ua", `"Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"`)
+	req.Header.Set("sec-ch-ua-mobile", "?0")
+	req.Header.Set("sec-ch-ua-platform", "macOS")
+	req.Header.Set("sec-fetch-dest", "empty")
+	req.Header.Set("sec-fetch-mode", "cors")
+	req.Header.Set("sec-fetch-site", "same-origin")
+	req.Header.Set("user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
+	req.Header.Set("x-csrf-token", csrfToken)
+	req.Header.Set("x-requested-with", "XMLHttpRequest")
+	req.Header.Set("Cookie", cookie)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Println("Usage: go run main.go <path_to_json_file>")
@@ -129,4 +169,12 @@ func main() {
 		fmt.Println("Login Error:", err)
 		return
 	}
+
+	query := "cha" // Example query
+	response, err := queryAutocomplete(cookie, authenticityToken, query)
+	if err != nil {
+		fmt.Println("Autocomplete Query Error:", err)
+		return
+	}
+	fmt.Println("Autocomplete Response:", response)
 }


### PR DESCRIPTION
Related to #24

Implement a method to query the autocomplete service.

* Add a new function `queryAutocomplete` in `main.go` to handle the autocomplete service request.
  * Construct the request using the provided cURL command as a model.
  * Send the request and return the response.
  * Call the `queryAutocomplete` function in the `main` function after successful login.
* Update the `README.md` to include instructions on how to use the new `queryAutocomplete` method.
  * Provide an example query usage.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/parentsquare-namehelp/pull/25?shareId=7d12e2e3-54c4-4181-bbcf-91e20428e740).