### PR TITLE
Implement a method to query the autocomplete service

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,23 @@ This repository includes a method to log in to ParentSquare using an authenticit
   }
 }
 ```
+
+## Autocomplete Query Method
+
+This repository now includes a method to query the ParentSquare autocomplete service.
+
+### Usage
+
+1. Call the `queryAutocompleteService` method with the school ID, limit, chat, and query parameters.
+2. The method returns the response from the autocomplete service.
+
+### Example
+
+```go
+autocompleteResults, err := queryAutocompleteService("732", "25", "1", "cha", psCookies)
+if err != nil {
+    fmt.Println("Autocomplete Query Error:", err)
+    return
+}
+fmt.Println("Autocomplete Results:", autocompleteResults)
+```


### PR DESCRIPTION
Related to #24

Implement a method to query the autocomplete service.

* Add a new function `queryAutocompleteService` in `main.go` to make a GET request to the autocomplete service endpoint.
* Update the `main` function in `main.go` to call `queryAutocompleteService` after successful login and print the autocomplete results.
* Update `README.md` to include instructions on how to use the new autocomplete query functionality and provide an example of calling the `queryAutocompleteService` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/parentsquare-namehelp/pull/29?shareId=011c0bc9-ea76-474a-9450-a26fe63f9d6a).