### PR TITLE
Implement a server that provides a route to the autocomplete method

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,31 @@ if err != nil {
 }
 fmt.Println("Autocomplete Results:", autocompleteResults)
 ```
+
+## Server Implementation
+
+This repository now includes an HTTP server to handle requests to the `/autocomplete` route.
+
+### Starting the Server
+
+1. Ensure you have a JSON file with your login credentials as shown in the example above.
+2. Run the server using the following command:
+
+```sh
+go run main.go <path_to_json_file>
+```
+
+Replace `<path_to_json_file>` with the path to your JSON file containing the login credentials.
+
+### Using the `/autocomplete` Route
+
+1. Start the server as described above.
+2. Send a GET request to the `/autocomplete` route with the required query parameters: `school_id`, `limit`, `chat`, and `query`.
+
+Example:
+
+```sh
+curl "http://localhost:8080/autocomplete?school_id=732&limit=25&chat=1&query=cha"
+```
+
+This will return the autocomplete results from the ParentSquare service.


### PR DESCRIPTION
Related to #30

Implement a server that provides a route to the autocomplete method.

* Add `autocompleteHandler` function in `main.go` to handle HTTP requests to the `/autocomplete` route.
* Modify the `main` function in `main.go` to start an HTTP server and define the `/autocomplete` route.
* Update the `queryAutocompleteService` function in `main.go` to accept parameters from the HTTP request.
* Remove parenthesis around if clauses in `main.go`.
* Update `README.md` to include instructions on how to start the server and use the `/autocomplete` route.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/parentsquare-namehelp/pull/31?shareId=7ccc6718-bc20-4eb1-bc2f-ec3ddd5ead12).