### PR TITLE
Implement a server that provides a route to the autocomplete method

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,27 @@ if err != nil {
 }
 fmt.Println("Autocomplete Results:", autocompleteResults)
 ```
+
+## HTTP Server
+
+This repository now includes an HTTP server that provides a route to the autocomplete method.
+
+### Running the Server
+
+1. Ensure you have a JSON file with your ParentSquare credentials (username and password).
+2. Run the server using the following command:
+
+```sh
+go run main.go <path_to_json_file>
+```
+
+### Example Usage of the `/autocomplete` Route
+
+1. Start the server as described above.
+2. Make a GET request to the `/autocomplete` route with the required query parameters (`school_id`, `limit`, `chat`, `query`).
+
+Example:
+
+```sh
+curl "http://localhost:8080/autocomplete?school_id=732&limit=25&chat=1&query=cha"
+```


### PR DESCRIPTION
Related to #30

Implement an HTTP server that provides a route to the autocomplete method using `psCookies` and includes a graceful exit.

* Add a `Server` struct with a `psCookies` field.
* Make `queryAutocompleteService` a method of the `Server` struct.
* Implement an HTTP server with a route `/autocomplete` that calls the `queryAutocompleteService` method.
* Implement a graceful exit for the HTTP server using a signal handler for `os.Interrupt` and `syscall.SIGTERM`.
* Update the `main` function to start the server.
* Add instructions for running the HTTP server and example usage of the `/autocomplete` route in `README.md`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/parentsquare-namehelp/pull/32?shareId=a56c6180-f26c-4efe-ae6f-30c4f0cf299f).