### PR TITLE
Add an '/api' prefix to the autocomplete server handlers

### DIFF
--- a/main.go
+++ b/main.go
@@ -211,7 +211,7 @@ func main() {
 
 	server := &Server{psCookies: psCookies}
 
-	http.HandleFunc("/autocomplete", server.autocompleteHandler)
+	http.HandleFunc("/api/autocomplete", server.autocompleteHandler)
 
 	srv := &http.Server{
 		Addr: ":8080",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      }
+    }
+  }
 })


### PR DESCRIPTION
Related to #33

Update the endpoint for the autocomplete handler to include an '/api' prefix.

* Change the endpoint in `http.HandleFunc` from `/autocomplete` to `/api/autocomplete` in `main.go`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/parentsquare-namehelp/pull/34?shareId=b7ba9a24-0943-4316-96b9-f4f3e9b8a03b).