### PR TITLE
Use tailwindcss classes for neat, compact, mobile friendly display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,50 +21,54 @@ function App() {
 	}, [query, schoolId, limit, chat]);
 
 	return (
-		<div>
-			<div>
-				<label>
+		<div className="p-4">
+			<div className="mb-4">
+				<label className="block text-sm font-medium text-gray-700">
 					School ID:
 					<input
 						type="number"
 						value={schoolId}
 						onChange={(e) => setSchoolId(Number(e.target.value))}
+						className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
 					/>
 				</label>
 			</div>
-			<div>
-				<label>
+			<div className="mb-4">
+				<label className="block text-sm font-medium text-gray-700">
 					Limit:
 					<input
 						type="number"
 						value={limit}
 						onChange={(e) => setLimit(Number(e.target.value))}
+						className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
 					/>
 				</label>
 			</div>
-			<div>
-				<label>
+			<div className="mb-4">
+				<label className="block text-sm font-medium text-gray-700">
 					Chat:
 					<input
 						type="number"
 						value={chat}
 						onChange={(e) => setChat(Number(e.target.value))}
+						className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
 					/>
 				</label>
 			</div>
-			<div>
-				<label>
+			<div className="mb-4">
+				<label className="block text-sm font-medium text-gray-700">
 					Query:
 					<input
 						type="text"
 						value={query}
 						onChange={(e) => setQuery(e.target.value)}
+						className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
 					/>
 				</label>
 			</div>
 			<div>
-				<h3>Results:</h3>
-				<pre>{results && JSON.stringify(results, null, 2)}</pre>
+				<h3 className="text-lg font-medium text-gray-900">Results:</h3>
+				<pre className="mt-2 p-4 bg-gray-100 rounded-md">{results && JSON.stringify(results, null, 2)}</pre>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Related to #37

Add tailwindcss classes for neat, compact, mobile-friendly display.

* Modify `src/App.tsx` to include tailwindcss classes for `div`, `label`, `input`, `h3`, and `pre` elements.
* Add padding, margin, text styling, and input styling classes to improve the layout and appearance of the components.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/parentsquare-namehelp/pull/38?shareId=36ed672c-558d-4fdc-a2d3-e4855bba8073).