### PR TITLE
Refactor by moving some autocomplete parameters from the frontend to a config.json file

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,7 @@
+{
+  "autocomplete": {
+    "school_id": "732",
+    "limit": "25",
+    "chat": "1"
+  }
+}

--- a/main.go
+++ b/main.go
@@ -22,8 +22,17 @@ type Credentials struct {
 	} `json:"login"`
 }
 
+type Config struct {
+	Autocomplete struct {
+		SchoolID int `json:"school_id"`
+		Limit    int `json:"limit"`
+		Chat     int `json:"chat"`
+	} `json:"autocomplete"`
+}
+
 type Server struct {
 	psCookies map[string]string
+	config    Config
 }
 
 func parseCredentials(filename string) (string, string, error) {
@@ -41,6 +50,23 @@ func parseCredentials(filename string) (string, string, error) {
 	}
 
 	return creds.Login.Username, creds.Login.Password, nil
+}
+
+func parseConfig(filename string) (Config, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return Config{}, err
+	}
+	defer file.Close()
+
+	var config Config
+	decoder := json.NewDecoder(file)
+	err = decoder.Decode(&config)
+	if err != nil {
+		return Config{}, err
+	}
+
+	return config, nil
 }
 
 func getSessionData() (string, map[string]string, error) {
@@ -161,17 +187,14 @@ func (s *Server) queryAutocompleteService(schoolID, limit, chat, query string) (
 }
 
 func (s *Server) autocompleteHandler(w http.ResponseWriter, r *http.Request) {
-	schoolID := r.URL.Query().Get("school_id")
-	limit := r.URL.Query().Get("limit")
-	chat := r.URL.Query().Get("chat")
 	query := r.URL.Query().Get("query")
 
-	if schoolID == "" || limit == "" || chat == "" || query == "" {
-		http.Error(w, "Missing query parameters", http.StatusBadRequest)
+	if query == "" {
+		http.Error(w, "Missing query parameter", http.StatusBadRequest)
 		return
 	}
 
-	results, err := s.queryAutocompleteService(schoolID, limit, chat, query)
+	results, err := s.queryAutocompleteService(fmt.Sprintf("%d", s.config.Autocomplete.SchoolID), fmt.Sprintf("%d", s.config.Autocomplete.Limit), fmt.Sprintf("%d", s.config.Autocomplete.Chat), query)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Autocomplete Query Error: %v", err), http.StatusInternalServerError)
 		return
@@ -182,15 +205,23 @@ func (s *Server) autocompleteHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	if len(os.Args) < 2 {
-		fmt.Println("Usage: go run main.go <path_to_json_file>")
+	if len(os.Args) < 3 {
+		fmt.Println("Usage: go run main.go <path_to_credentials_json_file> <path_to_config_json_file>")
 		return
 	}
 
-	jsonFile := os.Args[1]
-	username, password, err := parseCredentials(jsonFile)
+	credentialsFile := os.Args[1]
+	configFile := os.Args[2]
+
+	username, password, err := parseCredentials(credentialsFile)
 	if err != nil {
 		fmt.Println("Error parsing credentials:", err)
+		return
+	}
+
+	config, err := parseConfig(configFile)
+	if err != nil {
+		fmt.Println("Error parsing config:", err)
 		return
 	}
 
@@ -209,7 +240,7 @@ func main() {
 	}
 	fmt.Println("PS Cookies:", psCookies)
 
-	server := &Server{psCookies: psCookies}
+	server := &Server{psCookies: psCookies, config: config}
 
 	http.HandleFunc("/api/autocomplete", server.autocompleteHandler)
 

--- a/main.go
+++ b/main.go
@@ -24,9 +24,9 @@ type Credentials struct {
 
 type Config struct {
 	Autocomplete struct {
-		SchoolID int `json:"school_id"`
-		Limit    int `json:"limit"`
-		Chat     int `json:"chat"`
+		SchoolID string `json:"school_id"`
+		Limit    string `json:"limit"`
+		Chat     string `json:"chat"`
 	} `json:"autocomplete"`
 }
 
@@ -194,7 +194,7 @@ func (s *Server) autocompleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	results, err := s.queryAutocompleteService(fmt.Sprintf("%d", s.config.Autocomplete.SchoolID), fmt.Sprintf("%d", s.config.Autocomplete.Limit), fmt.Sprintf("%d", s.config.Autocomplete.Chat), query)
+	results, err := s.queryAutocompleteService(s.config.Autocomplete.SchoolID, s.config.Autocomplete.Limit, s.config.Autocomplete.Chat, query)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Autocomplete Query Error: %v", err), http.StatusInternalServerError)
 		return

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,6 @@
 import React, { useState, useEffect } from "react";
 
 function App() {
-	const [schoolId, setSchoolId] = useState(732);
-	const [limit, setLimit] = useState(25);
-	const [chat, setChat] = useState(1);
 	const [query, setQuery] = useState("");
 	const [results, setResults] = useState(null);
 
@@ -11,47 +8,17 @@ function App() {
 		if (query !== "") {
 			const fetchData = async () => {
 				const response = await fetch(
-					`/api/autocomplete?school_id=${schoolId}&limit=${limit}&chat=${chat}&query=${query}`,
+					`/api/autocomplete?query=${query}`,
 				);
 				const data = await response.json();
 				setResults(data);
 			};
 			fetchData();
 		}
-	}, [query, schoolId, limit, chat]);
+	}, [query]);
 
 	return (
 		<div>
-			<div>
-				<label>
-					School ID:
-					<input
-						type="number"
-						value={schoolId}
-						onChange={(e) => setSchoolId(Number(e.target.value))}
-					/>
-				</label>
-			</div>
-			<div>
-				<label>
-					Limit:
-					<input
-						type="number"
-						value={limit}
-						onChange={(e) => setLimit(Number(e.target.value))}
-					/>
-				</label>
-			</div>
-			<div>
-				<label>
-					Chat:
-					<input
-						type="number"
-						value={chat}
-						onChange={(e) => setChat(Number(e.target.value))}
-					/>
-				</label>
-			</div>
 			<div>
 				<label>
 					Query:


### PR DESCRIPTION
Related to #39

Refactor the autocomplete parameters by moving them from the frontend to a `config.json` file.

* **config.json**
  - Add a new `config.json` file with the specified contents: `{"autocomplete":{"school_id":"732","limit":"25","chat":"1"}}`.

* **src/App.tsx**
  - Remove the input fields for 'school id', 'limit' and 'chat'.
  - Update the `fetchData` function to remove the 'school id', 'limit' and 'chat' parameters from the URL.

* **main.go**
  - Add a `Config` struct to hold the autocomplete parameters.
  - Add a `parseConfig` function to load the `config.json` file.
  - Update the `Server` struct to include the `Config` struct.
  - Update the `main` function to load the `config.json` file and pass the parameters to the `Server` struct.
  - Update the `autocompleteHandler` function to use the parameters from the `Server` struct instead of the URL query parameters.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/parentsquare-namehelp/pull/40?shareId=090a4331-8018-4e26-9f00-986e0ccb2f27).