### PR TITLE
Render autocomplete results in a more meaningful way

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,13 @@ function App() {
 					`/api/autocomplete?query=${query}`,
 				);
 				const data = await response.json();
-				setResults(data);
+				const processedData = data.map((resultGroup) =>
+					resultGroup.map((result) => ({
+						name: result.name,
+						role: result.role.join(", "),
+					}))
+				);
+				setResults(processedData);
 			};
 			fetchData();
 		}
@@ -31,7 +37,14 @@ function App() {
 			</div>
 			<div>
 				<h3>Results:</h3>
-				<pre>{results && JSON.stringify(results, null, 2)}</pre>
+					<ul>
+						{results && results.flat().map((result, index) => (
+							<li key={index}>
+								<strong>Name:</strong> {result.name} <br />
+								<strong>Role:</strong> {result.role}
+							</li>
+						))}
+					</ul>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Related to #41

Update autocomplete response rendering to display name and role.

* **Backend changes:**
  - Add struct definitions for raw and processed autocomplete results in `main.go`.
  - Unmarshal raw results and process them to extract name and role.
  - Marshal processed results and send them to the frontend.

* **Frontend changes:**
  - Update `useEffect` hook in `src/App.tsx` to handle the processed response.
  - Render autocomplete results as a list of names and roles instead of a JSON string.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/parentsquare-namehelp/issues/41?shareId=XXXX-XXXX-XXXX-XXXX).