### PR TITLE
Render autocomplete results in a more meaningful way

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,16 @@ function App() {
 					`/api/autocomplete?query=${query}`,
 				);
 				const data = await response.json();
-				setResults(data);
+
+				const processedData = data.map((item) => {
+					const role = item[0].role[0] === "" ? `Parent of ${item[0].role[1]}` : item[0].role[0];
+					return {
+						name: item[0].name,
+						role: role,
+					};
+				});
+
+				setResults(processedData);
 			};
 			fetchData();
 		}
@@ -31,7 +40,13 @@ function App() {
 			</div>
 			<div>
 				<h3>Results:</h3>
-				<pre>{results && JSON.stringify(results, null, 2)}</pre>
+				<ul>
+					{results && results.map((result, index) => (
+						<li key={index}>
+							{result.name} - {result.role}
+						</li>
+					))}
+				</ul>
 			</div>
 		</div>
 	);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,15 +7,13 @@ function App() {
 	useEffect(() => {
 		if (query !== "") {
 			const fetchData = async () => {
-				const response = await fetch(
-					`/api/autocomplete?query=${query}`,
-				);
+				const response = await fetch(`/api/autocomplete?query=${query}`);
 				const data = await response.json();
 
-				const processedData = data.map((item) => {
-					const role = item[0].role[0] === "" ? `Parent of ${item[0].role[1]}` : item[0].role[0];
+				const processedData = data[0].map((item) => {
+					const role = item.role[0] === "" ? item.role[1] : item.role[0];
 					return {
-						name: item[0].name,
+						name: item.name,
 						role: role,
 					};
 				});
@@ -41,11 +39,12 @@ function App() {
 			<div>
 				<h3>Results:</h3>
 				<ul>
-					{results && results.map((result, index) => (
-						<li key={index}>
-							{result.name} - {result.role}
-						</li>
-					))}
+					{results &&
+						results.map((result, index) => (
+							<li key={index}>
+								{result.name} - {result.role}
+							</li>
+						))}
 				</ul>
 			</div>
 		</div>


### PR DESCRIPTION
Related to #41

Process the autocomplete response and render a list of names and roles in `src/App.tsx`.

* Fetch the autocomplete response and process it to extract names and roles.
* Check if the first role is an empty string and prepend "Parent of " to the second role.
* Update the state with the processed results.
* Render the processed results as a list of names and roles in the UI.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/parentsquare-namehelp/pull/44?shareId=28ac024e-b22c-412d-b865-d66fa03c5193).